### PR TITLE
修复死路径错误

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -81,7 +81,7 @@
         <ul>
             <li id = "title">Files</li>
             {%for item in items%}
-                <li id="file"><a href="http://localhost:9090/{{item}}">{{item}}</a><li>
+                <li id="file"><a href="/{{item}}">{{item}}</a><li>
             {%end%}
             <li id="footer"></li>
         </ul>


### PR DESCRIPTION
修复死路径错误，当非本机访问或非运行在9090端口时，写死的链接是错的
